### PR TITLE
feat: add ci test on new added or modified test on PR

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,26 @@
+name: Run Playwright Tests on Pull Request
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Fetch latest main branch
+        run: git fetch origin main
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright
+        run: npx playwright install chromium
+      - name: List playwright tests
+        run: git diff --name-only origin/main | grep '\.spec\.ts$'
+      - name: Run playwright tests
+        run: npx playwright test --retries=3 --workers=1 $(git diff --name-only origin/main | grep '\.spec\.ts$' | tr '\n' ' ')

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,8 +6,9 @@ on:
       - "**"
 
 jobs:
-  test:
+  playwright-test:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
As the discussion here https://github.com/playwrightvn/pw-discovery/issues/96  Adding CI to verify new or modified tests when a user creates a PR would help quickly identify if this PR is good to go.

Note: this workflow should be optional.